### PR TITLE
make list as iteratable

### DIFF
--- a/ch05/so_xml_to_tsv.py
+++ b/ch05/so_xml_to_tsv.py
@@ -83,8 +83,8 @@ def parsexml(filename):
 
     counter = 0
 
-    it = map(itemgetter(1),
-             iter(etree.iterparse(filename, events=('start',))))
+    it = iter(map(itemgetter(1),
+             iter(etree.iterparse(filename, events=('start',)))))
     root = next(it)  # get posts element
 
     for elem in it:


### PR DESCRIPTION
The variable "it" in parsexml is a simple list object and not iteratable.
So next(it) causes an error, the request fix it.

I tested on python 2.7.9.
